### PR TITLE
Fix VH backpack shapes cache to be thread safe

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.18.2
 forge_version=40.1.84
-mod_version=1.0.6
+mod_version=1.0.7
 jei_mc_version=1.18.2
 jei_version=9.7.0+
 curios_version=1.18.2-5.0.6.+

--- a/src/main/java/net/p3pp3rf1y/sophisticatedbackpacksvh/BackpackShapeProvider.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedbackpacksvh/BackpackShapeProvider.java
@@ -9,6 +9,7 @@ import net.p3pp3rf1y.sophisticatedcore.util.RotatedShapes;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class BackpackShapeProvider implements BackpackShapes.IShapeProvider {
 
@@ -50,7 +51,7 @@ public class BackpackShapeProvider implements BackpackShapes.IShapeProvider {
 			)
 	);
 
-	private static final Map<Integer, VoxelShape> SHAPES = new HashMap<>();
+	private static final Map<Integer, VoxelShape> SHAPES = new ConcurrentHashMap<>();
 
 	@Override
 	public VoxelShape getShape(Block backpackBlock, Direction dir, boolean leftTank, boolean rightTank, boolean battery) {


### PR DESCRIPTION
fixes https://github.com/P3pp3rF1y/SophisticatedBackpacks/issues/775, but for vh shapes
should be same as this commit https://github.com/P3pp3rF1y/SophisticatedBackpacks/commit/86ae0e72e2e3a7e6c8203ee99ab551a40dc3467e

ik vh is not being developed anymore, but it would be nice for wv